### PR TITLE
fix invalid memory address or nil pointer dereference error

### DIFF
--- a/subping.go
+++ b/subping.go
@@ -118,7 +118,7 @@ func (s *Subping) GetOnlineHosts() map[string]*ping.Statistics {
 	r := make(map[string]*ping.Statistics)
 
 	for ip, stats := range s.results {
-		if stats.PacketsRecv > 0 {
+		if stats != nil && stats.PacketsRecv > 0 {
 			r[ip] = stats
 		}
 	}


### PR DESCRIPTION
Fix: "panic: runtime error: invalid memory address or nil pointer dereference"