### PR TITLE
fix: first IP of CIDR range

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -36,6 +36,8 @@ func GenerateIPListFromCIDRString(cidr string) ([]net.IP, error) {
 func GenerateIPListFromCIDR(firstIp net.IP, cidr *net.IPNet) []net.IP {
 	var ips []net.IP
 
+	firstIp = firstIp.Mask(cidr.Mask)
+
 	for ip := firstIp; cidr.Contains(ip); inc(ip) {
 		newIP := make(net.IP, len(ip))
 		copy(newIP, ip)

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -36,9 +36,7 @@ func GenerateIPListFromCIDRString(cidr string) ([]net.IP, error) {
 func GenerateIPListFromCIDR(firstIp net.IP, cidr *net.IPNet) []net.IP {
 	var ips []net.IP
 
-	firstIp = firstIp.Mask(cidr.Mask)
-
-	for ip := firstIp; cidr.Contains(ip); inc(ip) {
+	for ip := firstIp.Mask(cidr.Mask); cidr.Contains(ip); inc(ip) {
 		newIP := make(net.IP, len(ip))
 		copy(newIP, ip)
 		ips = append(ips, newIP)


### PR DESCRIPTION
![image](https://github.com/fadhilyori/subping/assets/1548140/fb8c3c27-8723-4dd6-a102-b824149814f8)

fix first IP from CIDR notation input.

CIDR 192.168.25.0/21 : 
Correct CIDR range: 192.168.24.0 ~ 192.168.31.255

![image](https://github.com/fadhilyori/subping/assets/1548140/6a62a541-86f0-4d27-8e8d-01d583622afb)
