### PR TITLE
feat: implement mock and real pinger for ICMP operations, add testing…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ IMAGE_NAME=ghcr.io/fadhilyori/subping:latest
 build:
 	go build -ldflags=$(BUILD_FLAGS) -o out/$(BINARY_NAME) ./cmd/subping/
 
+test:
+	go test -v ./...
+
+test-mock:
+	CI=true go test -v ./...
+
+.PHONY: build test test-mock build-docker build-all
+
 build-docker:
 	docker build --build-arg VERSION=$(VERSION) -t $(IMAGE_NAME) .
 

--- a/internal/ping/mock_pinger.go
+++ b/internal/ping/mock_pinger.go
@@ -1,0 +1,177 @@
+package ping
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"time"
+)
+
+// MockPingerConfig defines the behavior of the mock pinger
+type MockPingerConfig struct {
+	// DefaultLatency is the default round-trip time for successful pings
+	DefaultLatency time.Duration
+
+	// DefaultPacketLoss is the default packet loss percentage (0.0 to 1.0)
+	DefaultPacketLoss float64
+
+	// HostConfigs allows configuring specific behavior for different hosts
+	HostConfigs map[string]MockHostConfig
+
+	// SimulateTiming adds realistic delay to simulate network latency
+	SimulateTiming bool
+}
+
+// MockHostConfig defines specific behavior for a particular host
+type MockHostConfig struct {
+	// Latency is the round-trip time for this host
+	Latency time.Duration
+
+	// PacketLoss is the packet loss percentage for this host (0.0 to 1.0)
+	PacketLoss float64
+
+	// ShouldError forces the ping to fail with an error
+	ShouldError bool
+
+	// ErrorMsg is the error message to return when ShouldError is true
+	ErrorMsg string
+}
+
+// mockPinger is a mock implementation for testing purposes
+// It provides deterministic ping results without requiring network access
+type mockPinger struct {
+	config MockPingerConfig
+	mu     sync.RWMutex
+}
+
+// NewMockPinger creates a new mock pinger with default configuration
+func NewMockPinger() Pinger {
+	return NewMockPingerWithConfig(MockPingerConfig{
+		DefaultLatency:     10 * time.Millisecond,
+		DefaultPacketLoss: 0.0,
+		HostConfigs:       make(map[string]MockHostConfig),
+		SimulateTiming:     true,
+	})
+}
+
+// NewMockPingerWithConfig creates a new mock pinger with custom configuration
+func NewMockPingerWithConfig(config MockPingerConfig) Pinger {
+	return &mockPinger{
+		config: config,
+	}
+}
+
+// Ping implements the Pinger interface with mock behavior
+func (p *mockPinger) Ping(ipAddress string, count int, interval time.Duration, timeout time.Duration) (Result, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	// Simulate network delay if configured
+	if p.config.SimulateTiming {
+		time.Sleep(1 * time.Millisecond) // Minimal delay to simulate network operation
+	}
+
+	// Check for host-specific configuration first
+	if hostConfig, exists := p.config.HostConfigs[ipAddress]; exists {
+		if hostConfig.ShouldError {
+			return Result{}, errors.New(hostConfig.ErrorMsg)
+		}
+
+		return p.calculateResult(count, hostConfig.Latency, hostConfig.PacketLoss), nil
+	}
+
+	// Default behavior based on IP address patterns
+	if p.isLocalhost(ipAddress) {
+		// Localhost should respond quickly and reliably
+		return p.calculateResult(count, 1*time.Millisecond, 0.0), nil
+	}
+
+	if p.isPrivateIP(ipAddress) {
+		// Private IPs should respond with moderate latency and low packet loss
+		return p.calculateResult(count, p.config.DefaultLatency, p.config.DefaultPacketLoss), nil
+	}
+
+	// Public/external IPs get higher latency and some packet loss to simulate real conditions
+	return p.calculateResult(count, 50*time.Millisecond, 0.1), nil
+}
+
+// SetHostConfig allows updating configuration for specific hosts (useful for testing)
+func (p *mockPinger) SetHostConfig(ipAddress string, config MockHostConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.config.HostConfigs == nil {
+		p.config.HostConfigs = make(map[string]MockHostConfig)
+	}
+	p.config.HostConfigs[ipAddress] = config
+}
+
+// calculateResult generates ping statistics based on input parameters
+func (p *mockPinger) calculateResult(count int, latency time.Duration, packetLoss float64) Result {
+	packetsRecv := int(float64(count) * (1.0 - packetLoss))
+
+	// Ensure at least 0 packets received
+	if packetsRecv < 0 {
+		packetsRecv = 0
+	}
+
+	// Convert packet loss from ratio to percentage
+	packetLossPercentage := packetLoss * 100.0
+
+	return Result{
+		AvgRtt:                latency,
+		PacketLoss:            packetLossPercentage,
+		PacketsSent:           count,
+		PacketsRecv:           packetsRecv,
+		PacketsRecvDuplicates: 0, // Mock doesn't simulate duplicates by default
+	}
+}
+
+// isLocalhost checks if the IP address is localhost
+func (p *mockPinger) isLocalhost(ipAddress string) bool {
+	return ipAddress == "localhost" ||
+		   ipAddress == "127.0.0.1" ||
+		   ipAddress == "::1"
+}
+
+// isPrivateIP checks if the IP address is in a private range
+func (p *mockPinger) isPrivateIP(ipAddress string) bool {
+	ip := net.ParseIP(ipAddress)
+	if ip == nil {
+		return false
+	}
+
+	// Check for private IP ranges
+	privateRanges := []string{
+		"10.0.0.0/8",        // RFC 1918
+		"172.16.0.0/12",     // RFC 1918
+		"192.168.0.0/16",    // RFC 1918
+		"fc00::/7",          // IPv6 Unique Local Addresses
+		"fe80::/10",         // IPv6 Link-Local Addresses
+	}
+
+	for _, cidr := range privateRanges {
+		_, network, _ := net.ParseCIDR(cidr)
+		if network != nil && network.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ClearHostConfigs removes all host-specific configurations
+func (p *mockPinger) ClearHostConfigs() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.config.HostConfigs = make(map[string]MockHostConfig)
+}
+
+// GetHostConfig returns the configuration for a specific host
+func (p *mockPinger) GetHostConfig(ipAddress string) (MockHostConfig, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	config, exists := p.config.HostConfigs[ipAddress]
+	return config, exists
+}

--- a/internal/ping/pinger.go
+++ b/internal/ping/pinger.go
@@ -1,0 +1,129 @@
+package ping
+
+import (
+	"os"
+	"time"
+)
+
+// Result represents the statistics from a ping operation
+type Result struct {
+	AvgRtt                time.Duration // Average round-trip time
+	PacketLoss            float64       // Packet loss percentage
+	PacketsSent           int           // Number of packets sent
+	PacketsRecv           int           // Number of packets received
+	PacketsRecvDuplicates int           // Number of duplicate packets received
+}
+
+// Statistics represents the full ping statistics, compatible with pro-bing.Statistics
+type Statistics struct {
+	// PacketsRecv is the number of packets received.
+	PacketsRecv int
+
+	// PacketsSent is the number of packets sent.
+	PacketsSent int
+
+	// PacketsRecvDuplicates is the number of duplicate responses there were to a sent packet.
+	PacketsRecvDuplicates int
+
+	// PacketLoss is the percentage of packets lost.
+	PacketLoss float64
+
+	// AvgRtt is the average round-trip time sent via this pinger.
+	AvgRtt time.Duration
+
+	// MinRtt is the minimum round-trip time sent via this pinger.
+	MinRtt time.Duration
+
+	// MaxRtt is the maximum round-trip time sent via this pinger.
+	MaxRtt time.Duration
+
+	// StdDevRtt is the standard deviation of the round-trip times sent via this pinger.
+	StdDevRtt time.Duration
+}
+
+// Pinger defines the interface for ping operations
+// This allows us to inject different implementations (real or mock) for testing
+type Pinger interface {
+	// Ping performs a ping operation on the given IP address and returns statistics
+	Ping(ipAddress string, count int, interval time.Duration, timeout time.Duration) (Result, error)
+}
+
+// NewPinger creates a new pinger instance based on the environment
+// In CI/GitHub Actions, it returns a mock pinger to avoid permission issues
+// Otherwise, it returns a real pinger for actual ICMP operations
+func NewPinger() Pinger {
+	// Check if we're in a CI environment
+	if isCIEnvironment() {
+		return NewMockPinger()
+	}
+	return NewRealPinger()
+}
+
+// NewPingerWithOptions creates a pinger with explicit type selection
+// This allows forcing a specific pinger type for testing or special scenarios
+func NewPingerWithOptions(pingerType string) Pinger {
+	switch pingerType {
+	case "mock":
+		return NewMockPinger()
+	case "real":
+		return NewRealPinger()
+	default:
+		return NewPinger() // auto-detect
+	}
+}
+
+// isCIEnvironment detects if we're running in a CI environment
+// It checks common environment variables set by CI systems
+func isCIEnvironment() bool {
+	// Check common CI environment variables
+	ciVars := []string{
+		"CI",                    // Generic CI (set by GitHub Actions, Travis, etc.)
+		"GITHUB_ACTIONS",        // GitHub Actions specific
+		"CONTINUOUS_INTEGRATION", // Generic CI
+		"TRAVIS",               // Travis CI
+		"CIRCLECI",             // CircleCI
+		"JENKINS_URL",          // Jenkins
+		"GITLAB_CI",            // GitLab CI
+		"APPVEYOR",             // AppVeyor
+		"CI_NAME",              // Various CI systems
+		"BUILDKITE",            // Buildkite
+		"SEMAPHORE",            // Semaphore CI
+	}
+
+	for _, v := range ciVars {
+		if os.Getenv(v) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// RunPing performs a ping operation to the specified IP address.
+// This is a utility function that provides the same interface as the original
+// standalone RunPing function but uses our internal pinger abstraction.
+// It sends the specified number of ping requests with the given interval and timeout.
+func RunPing(ipAddress string, count int, interval time.Duration, timeout time.Duration) Statistics {
+	// Use the real pinger for this utility function
+	pinger := NewRealPinger()
+
+	result, err := pinger.Ping(ipAddress, count, interval, timeout)
+	if err != nil {
+		// Return empty statistics on error to maintain compatibility
+		return Statistics{}
+	}
+
+	// Convert our internal Result to Statistics for compatibility
+	return Statistics{
+		PacketsSent:           result.PacketsSent,
+		PacketsRecv:           result.PacketsRecv,
+		PacketsRecvDuplicates: result.PacketsRecvDuplicates,
+		PacketLoss:            result.PacketLoss,
+		AvgRtt:               result.AvgRtt,
+		// Note: We don't track individual RTTs in our Result
+		// So min/max/stddev will be zero-initialized, which is acceptable for compatibility
+		MinRtt:               0,
+		MaxRtt:               0,
+		StdDevRtt:            0,
+	}
+}
+

--- a/internal/ping/pinger.go
+++ b/internal/ping/pinger.go
@@ -103,8 +103,8 @@ func isCIEnvironment() bool {
 // standalone RunPing function but uses our internal pinger abstraction.
 // It sends the specified number of ping requests with the given interval and timeout.
 func RunPing(ipAddress string, count int, interval time.Duration, timeout time.Duration) Statistics {
-	// Use the real pinger for this utility function
-	pinger := NewRealPinger()
+	// Use the auto-detecting pinger to respect CI environment
+	pinger := NewPinger()
 
 	result, err := pinger.Ping(ipAddress, count, interval, timeout)
 	if err != nil {

--- a/internal/ping/real_pinger.go
+++ b/internal/ping/real_pinger.go
@@ -1,0 +1,59 @@
+package ping
+
+import (
+	"runtime"
+	"time"
+
+	ping "github.com/prometheus-community/pro-bing"
+	"github.com/sirupsen/logrus"
+)
+
+// realPinger is the production implementation using pro-bing library
+// It performs actual ICMP ping operations
+type realPinger struct{}
+
+// NewRealPinger creates a new real pinger instance
+func NewRealPinger() Pinger {
+	return &realPinger{}
+}
+
+// Ping implements the Pinger interface using the pro-bing library
+// This performs actual network ping operations and returns real statistics
+func (p *realPinger) Ping(ipAddress string, count int, interval time.Duration, timeout time.Duration) (Result, error) {
+	// Create a new pinger for the target address
+	pinger, err := ping.NewPinger(ipAddress)
+	if err != nil {
+		logrus.Printf("Failed to create pinger for IP Address: %s\n", ipAddress)
+		return Result{}, err
+	}
+
+	// Configure pinger parameters
+	pinger.Count = count
+	pinger.Interval = interval
+
+	if timeout > 0 {
+		pinger.Timeout = timeout
+	}
+
+	// Windows requires privileged mode for ICMP operations
+	if runtime.GOOS == "windows" {
+		pinger.SetPrivileged(true)
+	}
+
+	// Execute the ping operation
+	err = pinger.Run()
+	if err != nil {
+		logrus.Printf("Failed to ping the address %s, %v\n", ipAddress, err.Error())
+		return Result{}, err
+	}
+
+	// Get the statistics and convert to our Result type
+	stats := pinger.Statistics()
+	return Result{
+		AvgRtt:                stats.AvgRtt,
+		PacketLoss:            stats.PacketLoss,
+		PacketsSent:           stats.PacketsSent,
+		PacketsRecv:           stats.PacketsRecv,
+		PacketsRecvDuplicates: stats.PacketsRecvDuplicates,
+	}, nil
+}

--- a/subping_test.go
+++ b/subping_test.go
@@ -1,6 +1,7 @@
 package subping_test
 
 import (
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -8,6 +9,22 @@ import (
 	"github.com/fadhilyori/subping"
 	"github.com/fadhilyori/subping/pkg/network"
 )
+
+// TestMain sets up the test environment
+// We force CI=true to ensure mock pinger is used for reliable testing
+func TestMain(m *testing.M) {
+	// Set CI environment variable to force mock pinger usage
+	// This ensures tests run reliably without requiring network privileges
+	os.Setenv("CI", "true")
+
+	// Run tests
+	code := m.Run()
+
+	// Clean up
+	os.Unsetenv("CI")
+
+	os.Exit(code)
+}
 
 func TestRunSubping(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
This pull request refactors the pinging logic in the codebase to use a new internal abstraction, allowing for both real and mock implementations. This makes the code more testable and robust, especially in CI environments. The changes introduce a new internal ping package, remove direct dependencies on external libraries from the main logic, and add support for dependency injection and configurable mock behavior.

### Ping Abstraction and Dependency Injection

* Introduced an internal `ping` package with a `Pinger` interface, and refactored `Subping` to use this interface for ping operations. This allows switching between real and mock implementations for production and testing. (`internal/ping/pinger.go`, `subping.go`) [[1]](diffhunk://#diff-3cf4f58013031ab4459890ff3ba45ff57b7fd503993ce11ff9a9f2080aec7046R1-R129) [[2]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L64-R73) [[3]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L96-R150) [[4]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5R189)
* Added dependency injection support in `Subping` via the new `NewSubpingWithPinger` constructor, enabling custom pinger implementations for tests or special scenarios. (`subping.go`) [[1]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L96-R150) [[2]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5R189)

### Mock and Real Pinger Implementations

* Added a mock pinger (`internal/ping/mock_pinger.go`) for reliable, configurable ping results in CI and tests, and a real pinger (`internal/ping/real_pinger.go`) that wraps the `pro-bing` library for actual ICMP operations. (`internal/ping/mock_pinger.go`, `internal/ping/real_pinger.go`) [[1]](diffhunk://#diff-6a3bb673c5a7c4de086278b7199a0f1e397c12a1a3180af5ff419d3783a8fc88R1-R177) [[2]](diffhunk://#diff-d8c4002f2360a58589a4f73e1e9e0e32fbe32d0f2022b9fe925a1e3ba4de379cR1-R59)
* The system auto-selects the mock pinger in CI environments, detected via environment variables, to avoid permission issues and flaky tests. (`internal/ping/pinger.go`, `subping_test.go`) [[1]](diffhunk://#diff-3cf4f58013031ab4459890ff3ba45ff57b7fd503993ce11ff9a9f2080aec7046R1-R129) [[2]](diffhunk://#diff-dce90e5f94d8a38534e4beed835d7db4fdd3c354a4b962dc70cb75cfde70311bR13-R28)

### Refactoring and Codebase Simplification

* Removed direct dependency on `pro-bing` from `subping.go` and replaced the custom `Result` type with the one from the internal ping package, simplifying the logic and improving maintainability. (`subping.go`) [[1]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L36-L43) [[2]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L64-R73) [[3]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L197-R236) [[4]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L216-R268)
* Updated the test suite to always use the mock pinger by setting the `CI` environment variable, ensuring tests do not require network privileges and are deterministic. (`subping_test.go`)

### Build and Testing Improvements

* Added new `make` targets for running tests and mock tests, improving developer workflow and CI integration. (`Makefile`)