### PR TITLE
Fix/log fatal in newsubping

### DIFF
--- a/cmd/subping/main.go
+++ b/cmd/subping/main.go
@@ -80,7 +80,7 @@ func runSubping(_ *cobra.Command, args []string) {
 		Subnet:     subnetString,
 		Count:      pingCount,
 		Interval:   pingInterval,
-		Timeout:    pingTimeout * time.Duration(pingCount),
+		Timeout:    pingTimeout,
 		MaxWorkers: pingMaxWorkers,
 		LogLevel:   "error",
 	})

--- a/subping.go
+++ b/subping.go
@@ -32,7 +32,7 @@ package subping
 
 import (
 	"errors"
-	"log"
+	"fmt"
 	"sync"
 	"time"
 
@@ -112,7 +112,7 @@ func NewSubping(opts *Options) (*Subping, error) {
 
 	ips, err := network.NewSubnetHostsIteratorFromCIDRString(opts.Subnet)
 	if err != nil {
-		log.Fatal(err.Error())
+		return nil, fmt.Errorf("failed to parse subnet: %w", err)
 	}
 
 	batchLimit, err := calculateMaxPartitionSize(ips.TotalHosts, opts.MaxWorkers)
@@ -162,7 +162,7 @@ func NewSubpingWithPinger(opts *Options, pinger ping.Pinger) (*Subping, error) {
 
 	ips, err := network.NewSubnetHostsIteratorFromCIDRString(opts.Subnet)
 	if err != nil {
-		log.Fatal(err.Error())
+		return nil, fmt.Errorf("failed to parse subnet: %w", err)
 	}
 
 	batchLimit, err := calculateMaxPartitionSize(ips.TotalHosts, opts.MaxWorkers)

--- a/subping.go
+++ b/subping.go
@@ -99,7 +99,7 @@ type Options struct {
 // NewSubping creates a new Subping instance with the provided options.
 func NewSubping(opts *Options) (*Subping, error) {
 	if opts.Subnet == "" {
-		return nil, errors.New("subnet should be in CIDR notation and cannot empty")
+		return nil, errors.New("subnet should be in CIDR notation and cannot be empty")
 	}
 
 	if opts.Count < 1 {
@@ -149,7 +149,7 @@ func NewSubping(opts *Options) (*Subping, error) {
 // This allows dependency injection for testing or special use cases
 func NewSubpingWithPinger(opts *Options, pinger ping.Pinger) (*Subping, error) {
 	if opts.Subnet == "" {
-		return nil, errors.New("subnet should be in CIDR notation and cannot empty")
+		return nil, errors.New("subnet should be in CIDR notation and cannot be empty")
 	}
 
 	if opts.Count < 1 {

--- a/subping.go
+++ b/subping.go
@@ -126,7 +126,7 @@ func NewSubping(opts *Options) (*Subping, error) {
 
 	logLevel, err := logrus.ParseLevel(opts.LogLevel)
 	if err != nil {
-		return nil, errors.New("max workers should be more than zero (0)")
+		return nil, fmt.Errorf("failed to parse log level: %w", err)
 	}
 
 	instance := &Subping{
@@ -176,7 +176,7 @@ func NewSubpingWithPinger(opts *Options, pinger ping.Pinger) (*Subping, error) {
 
 	logLevel, err := logrus.ParseLevel(opts.LogLevel)
 	if err != nil {
-		return nil, errors.New("max workers should be more than zero (0)")
+		return nil, fmt.Errorf("failed to parse log level: %w", err)
 	}
 
 	instance := &Subping{


### PR DESCRIPTION
This pull request refactors error handling in the `subping.go` package, making it more idiomatic and improving error messages. It also fixes a logic issue in the timeout calculation in `main.go`. The main changes are grouped below:

Error Handling Improvements:

* Replaced `log.Fatal` calls with proper error returns using `fmt.Errorf`, allowing errors to propagate instead of terminating the process. This change affects both `NewSubping` and `NewSubpingWithPinger` constructors. [[1]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L115-R115) [[2]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L165-R165)
* Improved error messages for subnet validation and log level parsing, making them more descriptive and accurate. [[1]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L102-R102) [[2]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L152-R152) [[3]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L129-R129) [[4]](diffhunk://#diff-ea29297ebcbdf7bf0ca0e7519c1b10c449e1a051a2fdd0df6d23dcaf301fc1c5L179-R179)

Code Quality and Logic Fixes:

* Changed the import from `log` to `fmt` in `subping.go` to support the new error formatting approach.
* Fixed the timeout calculation in `main.go` to use the provided `pingTimeout` directly rather than multiplying it by `pingCount`, ensuring the timeout value is correctly applied.