### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v6
 


### PR DESCRIPTION
Potential fix for [https://github.com/fadhilyori/subping/security/code-scanning/1](https://github.com/fadhilyori/subping/security/code-scanning/1)

In general, the fix is to explicitly define a least-privilege `permissions:` block for the workflow or for the specific job. Since this workflow only checks out code and runs Go build/tests, it only requires read access to the repository contents. We can safely set `contents: read` and rely on the default `none` for all other scopes.

The best fix with minimal functional change is to add a job-level `permissions:` block under the `build` job, right alongside `runs-on`. This keeps the permissions scoping explicit for this job without affecting other workflows. Concretely, in `.github/workflows/go.yml`, under `build:` and before or after `runs-on: ubuntu-latest`, insert:

```yaml
permissions:
  contents: read
```

No additional imports or methods are needed; this is purely a YAML configuration change inside the existing workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
